### PR TITLE
Enable building with static libraries.

### DIFF
--- a/book_examples/als/CMakeLists.txt
+++ b/book_examples/als/CMakeLists.txt
@@ -17,7 +17,7 @@ set(PTC_LATTICE_FILES
   z_als_lattice.f90
 )
 
-add_library(ptclattices SHARED
+add_library(ptclattices
   ${PTC_LATTICE_FILES}
 )
 
@@ -26,5 +26,6 @@ target_link_libraries(ptclattices ptc)
 install(
   TARGETS ptclattices LIBRARY
   DESTINATION PTC/lib
+  ARCHIVE DESTINATION PTC/lib
 )
 

--- a/fpp_ptc/CMakeLists.txt
+++ b/fpp_ptc/CMakeLists.txt
@@ -71,7 +71,7 @@ set(PTC_LIB_FILES
   St_pointers.f90
 )
 
-add_library(ptc SHARED
+add_library(ptc
   ${PTC_INCLUDE_FILES}
   ${PTC_LIB_FILES}
   ${FPP_LIB_FILES}
@@ -82,5 +82,6 @@ add_library(ptc SHARED
 install(
   TARGETS ptc LIBRARY
   DESTINATION PTC/lib
+  ARCHIVE DESTINATION PTC/lib
 )
 


### PR DESCRIPTION
Shared libraries can be built by passing -DBUILD_SHARED_LIBS=ON to the
cmake command.
